### PR TITLE
remove caching

### DIFF
--- a/src/gh_requests/pull_requests.py
+++ b/src/gh_requests/pull_requests.py
@@ -15,7 +15,6 @@ def get_default_executor() -> ThreadPoolExecutor:
     return ThreadPoolExecutor(max_workers=4)
 
 
-@st.cache_data(ttl=300, show_spinner=False)
 def fetch_pull_requests(pull_request_query: PullRequestQuery) -> list[PullRequestWithDetails]:
     gh = Github(st.session_state.token)
 


### PR DESCRIPTION
Caching causes issues when trying to fetch the pull requests again after making an action. With the concurrency improvements it seems it's unnecessary and problematic now. 